### PR TITLE
[Feat] #36 HatCategory 스크롤 영역 두번째 컬렉션뷰 구현 완료

### DIFF
--- a/CDS-APP-2-iOS.xcodeproj/project.pbxproj
+++ b/CDS-APP-2-iOS.xcodeproj/project.pbxproj
@@ -67,17 +67,18 @@
 		835898CF2B0FA68D00503CD1 /* SizeInfoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835898CE2B0FA68D00503CD1 /* SizeInfoCollectionViewCell.swift */; };
 		835898E42B0FFEFE00503CD1 /* TabbarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835898E32B0FFEFE00503CD1 /* TabbarItem.swift */; };
 		835898E72B0FFF2200503CD1 /* TabbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835898E62B0FFF2200503CD1 /* TabbarController.swift */; };
+		835899182B13016B00503CD1 /* MainInfoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835899172B13016B00503CD1 /* MainInfoDetailView.swift */; };
+		835A452A2B1490360026F6C8 /* SizeInfoHeaderCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A45292B1490360026F6C8 /* SizeInfoHeaderCollectionReusableView.swift */; };
+		835A452C2B1493760026F6C8 /* SizeInfoFooterCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A452B2B1493760026F6C8 /* SizeInfoFooterCollectionReusableView.swift */; };
 		A122D17F2B14DA82009752A7 /* MainCategoryDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A122D17E2B14DA82009752A7 /* MainCategoryDummy.swift */; };
 		A17FBB4E2B11B1EC009214D9 /* HatCategoryLayoutFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17FBB4D2B11B1EC009214D9 /* HatCategoryLayoutFactory.swift */; };
 		A17FBB552B11C227009214D9 /* HatCategoryMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17FBB542B11C227009214D9 /* HatCategoryMainView.swift */; };
 		A17FBB572B11C52F009214D9 /* RealTimeBestCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17FBB562B11C52F009214D9 /* RealTimeBestCollectionViewCell.swift */; };
-		835899182B13016B00503CD1 /* MainInfoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835899172B13016B00503CD1 /* MainInfoDetailView.swift */; };
-		835A452A2B1490360026F6C8 /* SizeInfoHeaderCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A45292B1490360026F6C8 /* SizeInfoHeaderCollectionReusableView.swift */; };
-		835A452C2B1493760026F6C8 /* SizeInfoFooterCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835A452B2B1493760026F6C8 /* SizeInfoFooterCollectionReusableView.swift */; };
 		A19559A12B0DC360002EED37 /* HatCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19559A02B0DC360002EED37 /* HatCategoryViewController.swift */; };
 		A19559B62B0DFAA0002EED37 /* NavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19559B52B0DFAA0002EED37 /* NavigationController+.swift */; };
 		A1A29DED2B0F223C00C9F25D /* HeaderCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A29DEC2B0F223C00C9F25D /* HeaderCollectionViewCell.swift */; };
 		A1A29DF02B0F37DA00C9F25D /* HeaderCategoryDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A29DEF2B0F37DA00C9F25D /* HeaderCategoryDummy.swift */; };
+		A1EB0FF22B15DA8A0023B8AD /* FilterCategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1EB0FF12B15DA8A0023B8AD /* FilterCategoryCollectionViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -140,22 +141,20 @@
 		835898CE2B0FA68D00503CD1 /* SizeInfoCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SizeInfoCollectionViewCell.swift; sourceTree = "<group>"; };
 		835898E32B0FFEFE00503CD1 /* TabbarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabbarItem.swift; sourceTree = "<group>"; };
 		835898E62B0FFF2200503CD1 /* TabbarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabbarController.swift; sourceTree = "<group>"; };
-
+		835899172B13016B00503CD1 /* MainInfoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainInfoDetailView.swift; sourceTree = "<group>"; };
+		835A45292B1490360026F6C8 /* SizeInfoHeaderCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeInfoHeaderCollectionReusableView.swift; sourceTree = "<group>"; };
+		835A452B2B1493760026F6C8 /* SizeInfoFooterCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeInfoFooterCollectionReusableView.swift; sourceTree = "<group>"; };
 		A122D17E2B14DA82009752A7 /* MainCategoryDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCategoryDummy.swift; sourceTree = "<group>"; };
 		A17FBB4D2B11B1EC009214D9 /* HatCategoryLayoutFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HatCategoryLayoutFactory.swift; sourceTree = "<group>"; };
 		A17FBB542B11C227009214D9 /* HatCategoryMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HatCategoryMainView.swift; sourceTree = "<group>"; };
 		A17FBB562B11C52F009214D9 /* RealTimeBestCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealTimeBestCollectionViewCell.swift; sourceTree = "<group>"; };
-
-		835899172B13016B00503CD1 /* MainInfoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainInfoDetailView.swift; sourceTree = "<group>"; };
-		835A45292B1490360026F6C8 /* SizeInfoHeaderCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeInfoHeaderCollectionReusableView.swift; sourceTree = "<group>"; };
-		835A452B2B1493760026F6C8 /* SizeInfoFooterCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeInfoFooterCollectionReusableView.swift; sourceTree = "<group>"; };
-
 		A18370082B0D01B700B64568 /* TabbarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarItem.swift; sourceTree = "<group>"; };
 		A183700C2B0D032200B64568 /* TabbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarController.swift; sourceTree = "<group>"; };
 		A19559A02B0DC360002EED37 /* HatCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HatCategoryViewController.swift; sourceTree = "<group>"; };
 		A19559B52B0DFAA0002EED37 /* NavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationController+.swift"; sourceTree = "<group>"; };
 		A1A29DEC2B0F223C00C9F25D /* HeaderCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderCollectionViewCell.swift; sourceTree = "<group>"; };
 		A1A29DEF2B0F37DA00C9F25D /* HeaderCategoryDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderCategoryDummy.swift; sourceTree = "<group>"; };
+		A1EB0FF12B15DA8A0023B8AD /* FilterCategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCategoryCollectionViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -590,6 +589,7 @@
 			children = (
 				A1A29DEC2B0F223C00C9F25D /* HeaderCollectionViewCell.swift */,
 				A17FBB562B11C52F009214D9 /* RealTimeBestCollectionViewCell.swift */,
+				A1EB0FF12B15DA8A0023B8AD /* FilterCategoryCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -697,6 +697,7 @@
 				2AA327B72B0B544A00732CE9 /* Adjust+.swift in Sources */,
 				2A0C02322B0A6407005764FA /* UIFont+.swift in Sources */,
 				835A452C2B1493760026F6C8 /* SizeInfoFooterCollectionReusableView.swift in Sources */,
+				A1EB0FF22B15DA8A0023B8AD /* FilterCategoryCollectionViewCell.swift in Sources */,
 				056F2F392B0DF1C700BA6ED8 /* UIStackView+.swift in Sources */,
 				2A0C02102B0A5EA5005764FA /* StringLiterals.swift in Sources */,
 				8358989C2B0DE62100503CD1 /* ProductInfoHeaderCollectionReusableView.swift in Sources */,

--- a/CDS-APP-2-iOS/Global/Literals/StringLiterals.swift
+++ b/CDS-APP-2-iOS/Global/Literals/StringLiterals.swift
@@ -29,7 +29,6 @@ enum StringLiterals {
         }
     }
     
-
     enum HatDetail {
         enum MainInfo {
             static let brandKR = "타입서비스"
@@ -82,7 +81,7 @@ enum StringLiterals {
             static let realSize = "실측 사이즈"
         }
     }
-            
+    
     enum HatCategory {
         enum header {
             static let all = "전체"
@@ -94,8 +93,41 @@ enum StringLiterals {
             static let trapper = "트루퍼"
             static let fedora = "페도라"
         }
+        
+        enum main {
+            enum realtimeBest {
+                enum product1 {
+                    static let name = "타입서비스"
+                    static let salePercent = "5%"
+                    static let price = "37,050"
+                }
+                enum product2 {
+                    static let name = "슬리피슬립"
+                    static let salePercent = "10%"
+                    static let price = "52,200"
+                }
+                enum product3 {
+                    static let name = "론론"
+                    static let salePercent = "15%"
+                    static let price = "140,250"
+                }
+                enum product4 {
+                    static let name = "시엔느"
+                    static let salePercent = "5%"
+                    static let price = "45,000"
+                }
+            }
+            
+            enum filter {
+                static let recommend = "추천순"
+                static let color = "색상"
+                static let priceRange = "가격대"
+                static let productInfo = "상품정보"
+                static let brand = "브랜드"
+            }
+        }
     }
-  
+    
     enum Home {
         enum chip {
             static let woman = "우먼"

--- a/CDS-APP-2-iOS/Presentation/HatCategory/Cell/FilterCategoryCollectionViewCell.swift
+++ b/CDS-APP-2-iOS/Presentation/HatCategory/Cell/FilterCategoryCollectionViewCell.swift
@@ -1,0 +1,76 @@
+//
+//  FilterCategoryCollectionViewCell.swift
+//  CDS-APP-2-iOS
+//
+//  Created by 최서연 on 11/28/23.
+//
+
+import UIKit
+
+final class FilterCategoryCollectionViewCell: UICollectionViewCell {
+    
+    //MARK: - set Properties
+    
+    private let label = UILabel()
+    private let downDetailImageView = UIImageView()
+
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.setUI()
+        self.setHierachy()
+        self.setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    //MARK: - set UI
+    
+    private func setUI() {
+        
+        self.do {
+            $0.layer.addBorder([.all], color: .border, width: 1)
+            $0.layer.cornerRadius = 18.adjusted
+        }
+        
+        label.do {
+            $0.font = UIFont.krSemiBold(ofSize: 12.adjusted)
+            $0.textColor = .lightGray
+        }
+        
+        downDetailImageView.do {
+            $0.image = ImageLiterals.icon.icDetailDownGraySmall
+        }
+    }
+    
+    //MARK: - set Hierachy
+    
+    private func setHierachy() {
+        self.addSubviews(label, downDetailImageView)
+    }
+    
+    //MARK: - set Layout
+    
+    private func setLayout() {
+        label.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(9.adjusted)
+            $0.leading.equalToSuperview().inset(14.adjusted)
+        }
+        
+        downDetailImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(9.adjusted)
+            $0.leading.equalTo(label.snp.trailing).offset(5.adjusted)
+        }
+    }
+    
+    //MARK: - Methods
+    
+    private func bindData(filterCategory: String) {
+        label.text = filterCategory
+    }
+    
+}

--- a/CDS-APP-2-iOS/Presentation/HatCategory/Cell/FilterCategoryCollectionViewCell.swift
+++ b/CDS-APP-2-iOS/Presentation/HatCategory/Cell/FilterCategoryCollectionViewCell.swift
@@ -31,19 +31,20 @@ final class FilterCategoryCollectionViewCell: UICollectionViewCell {
     //MARK: - set UI
     
     private func setUI() {
-        
         self.do {
-            $0.layer.addBorder([.all], color: .border, width: 1)
+            $0.layer.borderColor = UIColor.border.cgColor
+            $0.layer.borderWidth = 1
             $0.layer.cornerRadius = 18.adjusted
         }
         
         label.do {
             $0.font = UIFont.krSemiBold(ofSize: 12.adjusted)
-            $0.textColor = .lightGray
+            $0.textColor = .darkGray
         }
         
         downDetailImageView.do {
             $0.image = ImageLiterals.icon.icDetailDownGraySmall
+            $0.contentMode = .scaleAspectFit
         }
     }
     
@@ -63,14 +64,15 @@ final class FilterCategoryCollectionViewCell: UICollectionViewCell {
         
         downDetailImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(9.adjusted)
+            $0.bottom.equalToSuperview().inset(8.adjusted)
             $0.leading.equalTo(label.snp.trailing).offset(5.adjusted)
+            $0.trailing.equalToSuperview().inset(12.adjusted)
         }
     }
     
     //MARK: - Methods
     
-    private func bindData(filterCategory: String) {
+    func bindData(filterCategory: String) {
         label.text = filterCategory
     }
-    
 }

--- a/CDS-APP-2-iOS/Presentation/HatCategory/Dummy/MainCategoryDummy.swift
+++ b/CDS-APP-2-iOS/Presentation/HatCategory/Dummy/MainCategoryDummy.swift
@@ -17,10 +17,38 @@ struct RealtimeBestItem {
 extension RealtimeBestItem{
     static func realtimeBestDummy() -> [RealtimeBestItem] {
         return [
-            RealtimeBestItem(image: ImageLiterals.img.imgHatCategory1, brandName: "타입서비스", salePercent: "5%", itemPrice: "37,050"),
-            RealtimeBestItem(image: ImageLiterals.img.imgHatCategory2, brandName: "슬리피슬립", salePercent: "10%", itemPrice: "52,200"),
-            RealtimeBestItem(image: ImageLiterals.img.imgHatCategory3, brandName: "론론", salePercent: "15%", itemPrice: "140,250"),
-            RealtimeBestItem(image: ImageLiterals.img.imgHatCategory4, brandName: "시엔느", salePercent: "7%", itemPrice: "54,500")
+            RealtimeBestItem(image: ImageLiterals.img.imgHatCategory1,
+                             brandName: StringLiterals.HatCategory.main.realtimeBest.product1.name,
+                             salePercent: StringLiterals.HatCategory.main.realtimeBest.product1.salePercent,
+                             itemPrice: StringLiterals.HatCategory.main.realtimeBest.product1.price),
+            RealtimeBestItem(image: ImageLiterals.img.imgHatCategory2, 
+                             brandName: StringLiterals.HatCategory.main.realtimeBest.product2.name,
+                             salePercent: StringLiterals.HatCategory.main.realtimeBest.product2.salePercent,
+                             itemPrice: StringLiterals.HatCategory.main.realtimeBest.product2.price),
+            RealtimeBestItem(image: ImageLiterals.img.imgHatCategory3,
+                             brandName: StringLiterals.HatCategory.main.realtimeBest.product3.name,
+                             salePercent: StringLiterals.HatCategory.main.realtimeBest.product3.salePercent,
+                             itemPrice: StringLiterals.HatCategory.main.realtimeBest.product3.price),
+            RealtimeBestItem(image: ImageLiterals.img.imgHatCategory4,
+                             brandName: StringLiterals.HatCategory.main.realtimeBest.product4.name,
+                             salePercent: StringLiterals.HatCategory.main.realtimeBest.product4.salePercent,
+                             itemPrice: StringLiterals.HatCategory.main.realtimeBest.product4.price)
+        ]
+    }
+}
+
+struct FilterCategory {
+    let label: String
+}
+
+extension FilterCategory {
+    static func filterCategoryDummy() -> [FilterCategory] {
+        return [
+            FilterCategory(label: StringLiterals.HatCategory.main.filter.recommend),
+            FilterCategory(label: StringLiterals.HatCategory.main.filter.color),
+            FilterCategory(label: StringLiterals.HatCategory.main.filter.priceRange),
+            FilterCategory(label: StringLiterals.HatCategory.main.filter.productInfo),
+            FilterCategory(label: StringLiterals.HatCategory.main.filter.brand)
         ]
     }
 }

--- a/CDS-APP-2-iOS/Presentation/HatCategory/View/HatCategoryMainView.swift
+++ b/CDS-APP-2-iOS/Presentation/HatCategory/View/HatCategoryMainView.swift
@@ -17,6 +17,8 @@ final class HatCategoryMainView: UIView {
     private let divisionLine = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 0))
     lazy var productFilterCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
     
+    
+    
     //MARK: - Life Cycle
     
     override init(frame: CGRect) {
@@ -90,9 +92,10 @@ final class HatCategoryMainView: UIView {
         }
         
         productFilterCollectionView.snp.makeConstraints {
-            $0.top.equalTo(divisionLine.snp.bottom)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(57.adjusted)
+            $0.top.equalTo(divisionLine.snp.bottom).offset(13.adjusted)
+            $0.leading.equalToSuperview().inset(12.adjusted)
+            $0.trailing.equalToSuperview()
+            $0.height.equalTo(31.adjusted)
         }
     }
     

--- a/CDS-APP-2-iOS/Presentation/HatCategory/View/HatCategoryMainView.swift
+++ b/CDS-APP-2-iOS/Presentation/HatCategory/View/HatCategoryMainView.swift
@@ -15,6 +15,7 @@ final class HatCategoryMainView: UIView {
     lazy var realtimeBestCollectionView = UICollectionView(frame: .zero,
                                                            collectionViewLayout: UICollectionViewLayout())
     private let divisionLine = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 0))
+    lazy var productFilterCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
     
     //MARK: - Life Cycle
     
@@ -25,7 +26,8 @@ final class HatCategoryMainView: UIView {
         self.setHierachy()
         self.setLayout()
         
-        self.setrealtimeCollectionViewLayout()
+        self.setRealtimeCollectionViewLayout()
+        self.setProductFilterCollectionViewLayout()
     }
     
     @available(*, unavailable)
@@ -50,6 +52,11 @@ final class HatCategoryMainView: UIView {
         divisionLine.do {
             $0.layer.addBorder([.bottom], color: .border, width: 1)
         }
+        
+        productFilterCollectionView.do {
+            $0.contentInsetAdjustmentBehavior = .never
+            $0.showsHorizontalScrollIndicator = false
+        }
     }
     
     //MARK: - set Heirachy
@@ -57,7 +64,8 @@ final class HatCategoryMainView: UIView {
     private func setHierachy() {
         self.addSubviews(realtimeBestViewTitle,
                          realtimeBestCollectionView,
-                         divisionLine)
+                         divisionLine,
+                         productFilterCollectionView)
     }
     
     //MARK: - set Layout
@@ -80,15 +88,28 @@ final class HatCategoryMainView: UIView {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(1.adjusted)
         }
+        
+        productFilterCollectionView.snp.makeConstraints {
+            $0.top.equalTo(divisionLine.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(57.adjusted)
+        }
     }
     
     //MARK: - set collectionView FlowLayout
     
-    private func setrealtimeCollectionViewLayout() {
+    private func setRealtimeCollectionViewLayout() {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.scrollDirection = .horizontal
         flowLayout.minimumInteritemSpacing = 8
         self.realtimeBestCollectionView.setCollectionViewLayout(flowLayout, animated: false)
+    }
+    
+    private func setProductFilterCollectionViewLayout() {
+        let flowLayout = UICollectionViewFlowLayout()
+        flowLayout.scrollDirection = .horizontal
+        flowLayout.minimumInteritemSpacing = 6
+        self.productFilterCollectionView.setCollectionViewLayout(flowLayout, animated: false)
     }
 }
 

--- a/CDS-APP-2-iOS/Presentation/HatCategory/ViewController/HatCategoryViewController.swift
+++ b/CDS-APP-2-iOS/Presentation/HatCategory/ViewController/HatCategoryViewController.swift
@@ -20,6 +20,7 @@ final class HatCategoryViewController: UIViewController {
     
     private let hatCategoryMainView = HatCategoryMainView()
     private let realtimeBestDummy = RealtimeBestItem.realtimeBestDummy()
+    private let filterDummy = FilterCategory.filterCategoryDummy()
     
     // MARK: - Life Cycle
     
@@ -88,6 +89,7 @@ final class HatCategoryViewController: UIViewController {
         self.headerCollectionView.register(HeaderCollectionViewCell.self,
                                            forCellWithReuseIdentifier: HeaderCollectionViewCell.className)
         hatCategoryMainView.realtimeBestCollectionView.register(RealTimeBestCollectionViewCell.self, forCellWithReuseIdentifier: RealTimeBestCollectionViewCell.className)
+        hatCategoryMainView.productFilterCollectionView.register(FilterCategoryCollectionViewCell.self, forCellWithReuseIdentifier: FilterCategoryCollectionViewCell.className)
     }
     
     //MARK: - set Delegate
@@ -98,6 +100,9 @@ final class HatCategoryViewController: UIViewController {
         
         hatCategoryMainView.realtimeBestCollectionView.delegate = self
         hatCategoryMainView.realtimeBestCollectionView.dataSource = self
+        
+        hatCategoryMainView.productFilterCollectionView.delegate = self
+        hatCategoryMainView.productFilterCollectionView.dataSource = self
     }
     
     // MARK: - Methods
@@ -125,8 +130,11 @@ extension HatCategoryViewController: UICollectionViewDataSource {
         if collectionView == self.headerCollectionView {
             return headerDummy.count
         }
-        else {
+        else if collectionView == hatCategoryMainView.realtimeBestCollectionView{
             return realtimeBestDummy.count
+        }
+        else {
+            return filterDummy.count
         }
     }
     
@@ -139,10 +147,17 @@ extension HatCategoryViewController: UICollectionViewDataSource {
             return item
         }
         // 2. 실시간 베스트 수평 컬렉션뷰
-        else {
+        else if collectionView == hatCategoryMainView.realtimeBestCollectionView{
             guard let item = collectionView.dequeueReusableCell(withReuseIdentifier: RealTimeBestCollectionViewCell.className, for: indexPath) as? RealTimeBestCollectionViewCell else { return UICollectionViewCell() }
             
             item.bindData(item: realtimeBestDummy[indexPath.row])
+            return item
+        }
+        // 3. 필터링 카테고리 수평 컬렉션뷰
+        else {
+            guard let item = collectionView.dequeueReusableCell(withReuseIdentifier: FilterCategoryCollectionViewCell.className, for: indexPath) as? FilterCategoryCollectionViewCell else { return UICollectionViewCell() }
+            
+            item.bindData(filterCategory: filterDummy[indexPath.row].label)
             return item
         }
     }
@@ -159,8 +174,19 @@ extension HatCategoryViewController: UICollectionViewDelegateFlowLayout {
             let cellWidth = textWidth + 18
             return CGSize(width: cellWidth, height: 43.adjusted)
         }
-        else {
+        else if collectionView == hatCategoryMainView.realtimeBestCollectionView{
             return CGSize(width: 115.adjusted, height: 157.adjusted)
+        }
+        // 스클로영역의 컬렉션뷰 아이템의 동적 width 적용을 위한 익스텐션 추가
+        else {
+            let text = filterDummy[indexPath.item].label
+            let font = UIFont.krSemiBold(ofSize: 12.adjusted)
+            let image = ImageLiterals.icon.icDetailDownGraySmall
+            let textWidth = (text as NSString).size(withAttributes: [NSAttributedString.Key.font: font]).width
+            let imageWidth = image.size.width
+            
+            let cellWidth = textWidth + imageWidth + 31
+            return CGSize(width: cellWidth, height: 31.adjusted)
         }
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#36

👷 **작업한 내용**
-  HatCategory 스크롤 영역 두번째 컬렉션뷰 구현 완료했습니다~!

## 🚨 참고 사항
각 컬렉션뷰의 셀의 width를 동적으로 잡아주기 위해 컬렉션뷰의 extension을 이용했습니당.
```
// 스크롤영역의 컬렉션뷰 아이템의 동적 width 적용을 위한 익스텐션 추가
        else {
            let text = filterDummy[indexPath.item].label
            let font = UIFont.krSemiBold(ofSize: 12.adjusted)
            let image = ImageLiterals.icon.icDetailDownGraySmall
            let textWidth = (text as NSString).size(withAttributes: [NSAttributedString.Key.font: font]).width
            let imageWidth = image.size.width
            
            let cellWidth = textWidth + imageWidth + 31
            return CGSize(width: cellWidth, height: 31.adjusted)
        }
```
더 좋은 아이디어 있으면 리뷰 마구마구 남겨주세용 !!!!!!!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--|
|GIF|![Nov-28-2023 23-11-25](https://github.com/DO-SOPT-CDS-APP-2/CDS-APP-2-iOS/assets/102604192/141e5e81-ce46-4b6e-bc1f-0d6ecd15739c)|

## 📟 관련 이슈
- Resolved: #36
